### PR TITLE
Fixed demon offset, added functionality to differ between save file versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs/
+.vscode/
 Aogami.SMTV/obj
 Aogami.SMTV/bin
 Aogami.WinForms/obj

--- a/Aogami.WinForms/DemonSkillEditorForm.Designer.cs
+++ b/Aogami.WinForms/DemonSkillEditorForm.Designer.cs
@@ -90,7 +90,7 @@
             // 
             // SpecificSkillNameColumn
             // 
-            this.SpecificSkillNameColumn.Text = "Name";
+            this.SpecificSkillNameColumn.Text = "Text";
             this.SpecificSkillNameColumn.Width = 220;
             // 
             // DemonNameSkillsLabel

--- a/Aogami.WinForms/DemonSkillEditorForm.cs
+++ b/Aogami.WinForms/DemonSkillEditorForm.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Data;
 using System.Drawing;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -17,6 +18,14 @@ namespace Aogami.WinForms
         private readonly int _demonIndex;
         private readonly SMTVGameSaveData _openedGameSaveData;
         private int baseOffset;
+        
+        private static readonly Dictionary<int, int> GAME_VERSION_DEMON_OFFSET_PPER_INDEX_DICT = new Dictionary<int, int>()
+        {
+            { 0, 392 },
+            { 1, 424 }
+        };
+
+        private readonly int demonIndexOffset;
 
         public DemonSkillEditorForm(int demonIndex, string demonName, SMTVGameSaveData openedGameSaveData)
         {
@@ -24,14 +33,16 @@ namespace Aogami.WinForms
             _demonIndex = demonIndex;
             _openedGameSaveData = openedGameSaveData;
             DemonNameSkillsLabel.Text = $"{demonName}'s skills";
+            demonIndexOffset = GAME_VERSION_DEMON_OFFSET_PPER_INDEX_DICT[_openedGameSaveData.saveFileVersion];
             SerializeSkills();
         }
 
         private void SerializeSkills()
         {
             if (_demonIndex == 0) baseOffset = SMTVGameSaveDataOffsets.NahobinoSkillId;
-            else baseOffset = SMTVGameSaveDataOffsets.DemonSkillId + ((_demonIndex - 1) * 392);
+            else baseOffset = SMTVGameSaveDataOffsets.DemonSkillId + ((_demonIndex - 1) * demonIndexOffset);
 
+            
             for (int i = 0; i < 8; i++)
             {
                 int offsetSum = baseOffset + (i * 8);
@@ -41,6 +52,7 @@ namespace Aogami.WinForms
                     ListViewItem skillItem = new(skillName);
                     skillItem.Name = skillName;
                     skillItem.Tag = skillId;
+                    skillItem.Text = $"{skillName}"; // Segregate name (being used as key sometimes) from display value
                     SpecificDemonSkillsListView.Items.Add(skillItem);
                 }
             }
@@ -62,7 +74,7 @@ namespace Aogami.WinForms
         private void SaveDemonSkills()
         {
             if (_demonIndex == 0) baseOffset = SMTVGameSaveDataOffsets.NahobinoSkillId;
-            else baseOffset = SMTVGameSaveDataOffsets.DemonSkillId + ((_demonIndex - 1) * 392);
+            else baseOffset = SMTVGameSaveDataOffsets.DemonSkillId + ((_demonIndex - 1) * demonIndexOffset);
 
             for (int i = 0; i < 8; i++)
             {

--- a/Aogami.WinForms/MainForm.cs
+++ b/Aogami.WinForms/MainForm.cs
@@ -9,6 +9,12 @@ namespace Aogami.WinForms
     {
         private SMTVGameSaveData? openedGameSaveData;
         private bool readyForUserInput;
+        private int demonIndexOffset;
+        private static readonly Dictionary<int, int> GAME_VERSION_DEMON_OFFSET_PPER_INDEX_DICT = new Dictionary<int, int>()
+        {
+            { 0, 392 },
+            { 1, 424 }
+        };
 
         public MainForm()
         {
@@ -51,6 +57,8 @@ namespace Aogami.WinForms
         {
             if (openedGameSaveData == null) return;
             readyForUserInput = false;
+
+            demonIndexOffset = GAME_VERSION_DEMON_OFFSET_PPER_INDEX_DICT[openedGameSaveData.saveFileVersion];
 
             FirstNameTextBox.Text = openedGameSaveData.RetrieveString(SMTVGameSaveDataOffsets.FirstName, 16, true);
             LastNameTextBox.Text = openedGameSaveData.RetrieveString(SMTVGameSaveDataOffsets.LastName, 16, true);
@@ -262,14 +270,14 @@ namespace Aogami.WinForms
                     openedGameSaveData = await SMTVGameSaveData.Create(ofd.FileName);
                     if (openedGameSaveData == null)
                     {
-                        MessageBox.Show("It looks like this is not a valid save file. Make sure you try to open an encrypted, 388KB Shin Megami Tensei V save file.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show("It looks like this is not a valid save file. Make sure you try to open an encrypted, Shin Megami Tensei V save file.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         Text = "Aogami";
                         SaveChangesButton.Enabled = false;
                         ChangeFormSize(333, 119);
                         return;
                     }
 
-                    Text = "Aogami — Shin Megami Tensei V Save Editor";
+                    Text = "Aogami Shin Megami Tensei V Save Editor";
                     SaveChangesButton.Enabled = true;
                     ChangeFormSize(600, 420);
                     SerializeSaveFileData();
@@ -286,14 +294,14 @@ namespace Aogami.WinForms
                     openedGameSaveData = await SMTVGameSaveData.Load(ofd.FileName);
                     if (openedGameSaveData == null)
                     {
-                        MessageBox.Show("It looks like this is not a valid save file. Make sure you try to open an encrypted, 388KB Shin Megami Tensei V save file.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show("It looks like this is not a valid save file. Make sure you try to open an decrypted, Shin Megami Tensei V save file.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         Text = "Aogami";
                         SaveChangesButton.Enabled = false;
                         ChangeFormSize(333, 119);
                         return;
                     }
 
-                    Text = "Aogami — Shin Megami Tensei V Save Editor";
+                    Text = "Aogami Shin Megami Tensei V Save Editor";
                     SaveChangesButton.Enabled = true;
                     ChangeFormSize(600, 420);
                     SerializeSaveFileData();
@@ -596,7 +604,7 @@ namespace Aogami.WinForms
             }
             else
             {
-                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * 392;
+                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * demonIndexOffset;
 
                 openedGameSaveData.UpdateInt32(SMTVGameSaveDataOffsets.DemonExp + offsetSum, (int)DemonExperienceNumUpDown.Value);
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonLevel + offsetSum, (short)DemonLevelNumUpDown.Value);
@@ -638,7 +646,7 @@ namespace Aogami.WinForms
             }
             else
             {
-                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * 392;
+                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * demonIndexOffset;
                 openedGameSaveData.UpdateInt32(SMTVGameSaveDataOffsets.DemonExp + offsetSum, (int)DemonExperienceNumUpDown.Value);
             }
             readyForUserInput = true;
@@ -657,7 +665,7 @@ namespace Aogami.WinForms
             }
             else
             {
-                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * 392;
+                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * demonIndexOffset;
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonLevel + offsetSum, (short)DemonLevelNumUpDown.Value); ;
             }
             readyForUserInput = true;
@@ -675,7 +683,7 @@ namespace Aogami.WinForms
             }
             else
             {
-                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * 392;
+                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * demonIndexOffset;
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonHpBase + offsetSum, (short)DemonHpNumericUpDown.Value);
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonHpBalm + offsetSum, (short)DemonHpNumericUpDown.Value);
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonHpTotal + offsetSum, (short)DemonHpNumericUpDown.Value);
@@ -695,7 +703,7 @@ namespace Aogami.WinForms
             }
             else
             {
-                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * 392;
+                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * demonIndexOffset;
                 short newTotalMp = (short)DemonMpNumericUpDown.Value;
                 short baseMp = openedGameSaveData.RetrieveInt16(SMTVGameSaveDataOffsets.DemonMpBase + offsetSum);
                 if (baseMp <= 0) baseMp = (short)(newTotalMp / 4);
@@ -720,7 +728,7 @@ namespace Aogami.WinForms
             }
             else
             {
-                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * 392;
+                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * demonIndexOffset;
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonStrength + offsetSum, (short)StrengthNumUpDown.Value);
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonStrength2 + offsetSum, (short)StrengthNumUpDown.Value);
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonStrength3 + offsetSum, (short)StrengthNumUpDown.Value);
@@ -740,7 +748,7 @@ namespace Aogami.WinForms
             }
             else
             {
-                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * 392;
+                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * demonIndexOffset;
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonVitality + offsetSum, (short)VitalityNumUpDown.Value);
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonVitality2 + offsetSum, (short)VitalityNumUpDown.Value);
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonVitality3 + offsetSum, (short)VitalityNumUpDown.Value);
@@ -760,7 +768,7 @@ namespace Aogami.WinForms
             }
             else
             {
-                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * 392;
+                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * demonIndexOffset;
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonMagic + offsetSum, (short)MagicNumUpDown.Value);
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonMagic2 + offsetSum, (short)MagicNumUpDown.Value);
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonMagic3 + offsetSum, (short)MagicNumUpDown.Value);
@@ -780,7 +788,7 @@ namespace Aogami.WinForms
             }
             else
             {
-                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * 392;
+                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * demonIndexOffset;
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonAgility + offsetSum, (short)AgilityNumUpDown.Value);
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonAgility2 + offsetSum, (short)AgilityNumUpDown.Value);
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonAgility3 + offsetSum, (short)AgilityNumUpDown.Value);
@@ -800,7 +808,7 @@ namespace Aogami.WinForms
             }
             else
             {
-                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * 392;
+                int offsetSum = (DemonStockListView.SelectedIndices[0] - 1) * demonIndexOffset;
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonLuck + offsetSum, (short)LuckNumUpDown.Value);
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonLuck2 + offsetSum, (short)LuckNumUpDown.Value);
                 openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonLuck3 + offsetSum, (short)LuckNumUpDown.Value);
@@ -822,7 +830,7 @@ namespace Aogami.WinForms
             if (openedGameSaveData == null || !readyForUserInput || DemonStockListView.SelectedItems.Count != 1) return;
             readyForUserInput = false;
             int demonIndex = (int)DemonStockListView.SelectedItems[0].Tag;
-            int offsetSum = (demonIndex - 1) * 392;
+            int offsetSum = (demonIndex - 1) * demonIndexOffset;
             SMTVDemon? newDemon = SMTVDemonCollection.DemonList.Values.FirstOrDefault(x => x.Index == DemonTypeComboBox.SelectedIndex);
             if (newDemon != null)
             {
@@ -845,7 +853,7 @@ namespace Aogami.WinForms
             }
 
             readyForUserInput = false;
-            int offsetSum = (demonIndex - 1) * 392;
+            int offsetSum = (demonIndex - 1) * demonIndexOffset;
             openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonId + offsetSum, -1);
             openedGameSaveData.UpdateInt32(SMTVGameSaveDataOffsets.DemonExp + offsetSum, 0);
             openedGameSaveData.UpdateInt16(SMTVGameSaveDataOffsets.DemonLevel + offsetSum, 1);


### PR DESCRIPTION
Demon offset updated from 392 to 424.

Added attribute save file version to SMTVGameSaveData to differ between base & vengance saves.

Ideally there should be a more proper way to tell the save versions apart, but for now we can live with checking the save file size.